### PR TITLE
:art: Improve gulp async task

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('assets', function() {
 });
 
 // build HTML files using Metalsmith
-gulp.task('metalsmith', function() {
+gulp.task('metalsmith', function(cb) {
     metalsmith(".")
         .clean(false)
         .source("content")
@@ -58,6 +58,7 @@ gulp.task('metalsmith', function() {
         .use(htmlMinifier())
         .build(function(err) {
             if (err) throw err;
+            cb();
         });
 });
 


### PR DESCRIPTION
If you are doing asynchronous things in a gulp task you either need to return a vinyl stream or take the first argument as a callback and call it when the operation is finished.
See https://github.com/gulpjs/gulp/blob/master/docs/API.md#async-task-support